### PR TITLE
Add support for python3

### DIFF
--- a/elf.py
+++ b/elf.py
@@ -1,3 +1,4 @@
+from elftools.common.py3compat import str2bytes, bytes2str
 from elftools.elf.elffile import ELFFile
 
 from sys import argv
@@ -14,7 +15,7 @@ class ElfParser():
         self.filename = filename
         f = open(filename, "rb")
         self.elf = ELFFile(f)
-        
+
         self.rx_vaddr = -1
         self.parse_segments()
 
@@ -31,7 +32,7 @@ class ElfParser():
 
     def disas_around_addr(self, addr):
         """ Addr is offset in executable segment """
-	if addr & 1 != 0:
+        if addr & 1 != 0:
             addr &= ~1
             thumb = True
         else:
@@ -47,11 +48,11 @@ class ElfParser():
             args += ['-Mforce-thumb']
 
         output = subprocess.check_output(args)
-        lines = output.split("\n")
+        lines = output.split(str2bytes("\n"))
         keep = False
         new_lines = []
         for line in lines:
-            if "Disassembly of section" in line:
+            if str2bytes("Disassembly of section") in line:
                 keep = True
                 continue
             if keep:
@@ -59,6 +60,7 @@ class ElfParser():
         lines = new_lines
 
         for x, line in enumerate(lines):
+            line = bytes2str(line)
             if "{:x}:".format(addr) in line:
                 line = line[line.find("\t"):]
                 line = "!!! \t{} !!!".format(line)
@@ -79,7 +81,7 @@ class ElfParser():
     def addr2line(self, addr):
         """ Addr is offset in executable segment """
         addr += self.rx_vaddr
-        self.a2l.stdin.write(hex(addr) + "\n")
+        self.a2l.stdin.write(str2bytes(hex(addr) + "\n"))
         self.a2l.stdin.flush()
         out = self.a2l.stdout.readline()
         return out.strip()

--- a/util.py
+++ b/util.py
@@ -1,13 +1,25 @@
+from elftools.common.py3compat import str2bytes
+
 import string
 import struct
 
 
 def u16(buf, off):
-    return struct.unpack("<H", buf[off:off+2])[0]
+    buf = buf[off:off+2]
+    try:
+        buf = str2bytes(buf)
+    except AttributeError:
+        pass
+    return struct.unpack("<H", buf)[0]
 
 
 def u32(buf, off):
-    return struct.unpack("<I", buf[off:off+4])[0]
+    buf = buf[off:off+4]
+    try:
+        buf = str2bytes(buf)
+    except AttributeError:
+        pass
+    return struct.unpack("<I", buf)[0]
 
 
 def c_str(buf, off):
@@ -29,4 +41,4 @@ def hexdump(src, length=16, sep='.'):
             hex = "%s %s" % (hex[:24], hex[24:])
         printable = ''.join(["%s" % FILTER[ord(x)] for x in chars])
         lines.append("%08x:  %-*s  |%s|\n" % (c, length*3, hex, printable))
-    print ''.join(lines)
+    print(''.join(lines))


### PR DESCRIPTION
This adds support for python3 to vita-parse-core by adding the necessary `bytes <-> str` (which are different in python3 but not in python2) conversion functions where needed.

These functions are implemented as identities in python2, so it still works fine in python2.

Thanks a lot for this utility!