### PR TITLE
update pyelftools for python 3.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pyelftools==0.24
+pyelftools==0.27


### PR DESCRIPTION
Update version of pyelftools for python 3.9+ compatibility